### PR TITLE
Id cleanup

### DIFF
--- a/bge_game_system/game_loop.py
+++ b/bge_game_system/game_loop.py
@@ -2,7 +2,7 @@ from collections import OrderedDict, namedtuple
 from contextlib import contextmanager
 
 from network.enums import Netmodes
-from network.network import Network
+from network.network import Network, UnreliableSocketWrapper
 from network.replicable import Replicable
 from network.signals import *
 from network.world_info import WorldInfo
@@ -335,9 +335,18 @@ class Client(GameLoop):
         timeout = Timer(self.graceful_exit_time_out)
         timeout.on_target = quit_func
 
+    def on_step(self, delta_time):
+        network = self.network_system
+        if hasattr(network.socket, "update"):
+            network.socket.update()
+
+        super().on_step(delta_time)
+
     @staticmethod
     def create_network():
-        return Network("", 0)
+        network = Network("", 0)
+        #network.socket = UnreliableSocketWrapper(network.socket)
+        return network
 
     @ConnectToSignal.on_global
     def new_connection(self, address, port):

--- a/bge_game_system/physics.py
+++ b/bge_game_system/physics.py
@@ -136,7 +136,8 @@ class BGEClientPhysics(BGEPhysicsSystem):
             return
 
         # Make a list of actors which aren't us
-        other_actors = [a for a in WorldInfo.subclass_of(Actor) if a is not target]
+        other_actors = WorldInfo.subclass_of(Actor).copy()
+        other_actors.discard(target)
 
         with self.protect_exemptions(other_actors):
             self._update_bullet(delta_time)

--- a/demos/example_utilities/remote_debugging/client.py
+++ b/demos/example_utilities/remote_debugging/client.py
@@ -17,7 +17,7 @@ def run_interface(namespace):
     if namespace.get("waiting"):
         return
 
-    terminal = terminals[0]
+    terminal = next(iter(terminals))
     command = multiline_input()
 
     namespace['waiting'] = True

--- a/demos/test_panda/actors.py
+++ b/demos/test_panda/actors.py
@@ -8,10 +8,10 @@ from network.enums import Roles
 
 
 class TestActor(Actor):
+    mass = Attribute(1.0, notify=True)
+    roles = Attribute(Roles(Roles.authority, Roles.autonomous_proxy))
 
     replicate_physics_to_owner = False
-    mass = Attribute(0.0, notify=True)
-    roles = Attribute(Roles(Roles.authority, Roles.autonomous_proxy))
 
     def on_initialised(self):
         super().on_initialised()
@@ -20,13 +20,14 @@ class TestActor(Actor):
 
     def conditions(self, is_owner, is_complaint, is_initial):
         yield from super().conditions(is_owner, is_complaint, is_initial)
+
         yield "mass"
 
     def on_notify(self, name):
         super().on_notify(name)
 
         if name == "mass":
-            self.physics._game_object.mass = self.mass
+            self.physics.mass = self.mass
 
     @simulated
     @CollisionSignal.on_context
@@ -35,7 +36,7 @@ class TestActor(Actor):
 
     @LogicUpdateSignal.on_global
     def on_update(self, delta_time):
-        # new_pos = self.transform.world_position
-        # new_pos.y += 1 / 10
-        # self.transform.world_position = new_pos
+        new_pos = self.transform.world_position
+        new_pos.z -= 1 / 200
+        self.transform.world_position = new_pos
         return

--- a/demos/test_panda/actors.py
+++ b/demos/test_panda/actors.py
@@ -24,10 +24,10 @@ class TestActor(Actor):
         yield "mass"
 
     def on_notify(self, name):
-        super().on_notify(name)
-
         if name == "mass":
             self.physics.mass = self.mass
+        else:
+            super().on_notify(name)
 
     @simulated
     @CollisionSignal.on_context
@@ -36,7 +36,8 @@ class TestActor(Actor):
 
     @LogicUpdateSignal.on_global
     def on_update(self, delta_time):
-        new_pos = self.transform.world_position
-        new_pos.z -= 1 / 200
-        self.transform.world_position = new_pos
+
+        # new_pos = self.transform.world_position
+        # new_pos.z -= 1 / 200
+        # self.transform.world_position = new_pos
         return

--- a/demos/test_panda/app.py
+++ b/demos/test_panda/app.py
@@ -26,9 +26,8 @@ class Rules(ReplicationRulesBase):
         replicable.deregister()
 
     def post_initialise(self, replication_stream):
-        x = 0
-        cont = TestPandaPlayerController(register_immediately=x)
-        cont.possess(TestActor(register_immediately=x))
+        cont = TestPandaPlayerController()
+        cont.possess(TestActor())
         return cont
 
     def is_relevant(self, connection, replicable):

--- a/demos/test_panda/app.py
+++ b/demos/test_panda/app.py
@@ -1,16 +1,20 @@
 from panda_game_system.game_loop import Client, Server
 
-from .actors import *
-
+from network.connection import Connection
 from network.world_info import WorldInfo
 from network.rules import ReplicationRulesBase
 from network.enums import Netmodes
 
 from game_system.controllers import PawnController
+from game_system.clock import Clock
 from game_system.entities import Actor
 from game_system.replication_info import ReplicationInfo
 
+from .actors import *
 from .controllers import TestPandaPlayerController
+
+
+classes = dict(server=Server, client=Client)
 
 
 class Rules(ReplicationRulesBase):
@@ -22,8 +26,9 @@ class Rules(ReplicationRulesBase):
         replicable.deregister()
 
     def post_initialise(self, replication_stream):
-        cont = TestPandaPlayerController(register_immediately=True)
-        cont.possess(TestActor())
+        x = 0
+        cont = TestPandaPlayerController(register_immediately=x)
+        cont.possess(TestActor(register_immediately=x))
         return cont
 
     def is_relevant(self, connection, replicable):
@@ -36,16 +41,29 @@ class Rules(ReplicationRulesBase):
         elif isinstance(replicable, ReplicationInfo):
             return True
 
+        elif isinstance(replicable, Clock):
+            return True
+
         elif replicable.always_relevant:
             return True
 
 
-classes = dict(server=Server, client=Client)
+def init_game():
+    if WorldInfo.netmode == Netmodes.server:
+        floor = TestActor(register_immediately=True)
+        floor.transform.world_position = [0, 30, -1]
+
+        floor.physics.mass = 0.0
+        floor.mass = 0.0
+
+    else:
+        Connection.create_connection("localhost", 1200)
 
 
 def run(mode):
     try:
         cls = classes[mode]
+
     except KeyError:
         print("Unable to start {}".format(mode))
         return
@@ -58,13 +76,7 @@ def run(mode):
 
     game_loop = cls()
 
-    # Create floor
-    #floor = TestActor(register_immediately=True)
-
-    floor = TestActor(register_immediately=True)
-    floor.transform.world_position = [0, 30, -1]
-    floor.physics._node.set_mass(0.0)
-    floor.mass = 0.0
+    init_game()
 
     game_loop.delegate()
     del game_loop

--- a/demos/test_panda/controllers.py
+++ b/demos/test_panda/controllers.py
@@ -43,7 +43,10 @@ class TestPandaPlayerController(PlayerPawnController):
         pawn = self.pawn
 
         velocity = Vector((0.0, y_speed, 0.0))
-        velocity.rotate(pawn.transform.world_orientation)
+        try:
+            velocity.rotate(pawn.transform.world_orientation)
+        except AttributeError:
+            base.invoke_exit()
 
         angular = Vector((0.0, 0.0, rotation_speed))
 

--- a/game_system/controllers.py
+++ b/game_system/controllers.py
@@ -44,9 +44,12 @@ class PawnController(Replicable):
     def on_notify(self, name):
         if name == "pawn":
             self.possess(self.pawn)
+            print("POSSESS")
 
     def on_deregistered(self):
         self.pawn.deregister()
+
+        super().on_deregistered()
 
     def possess(self, pawn):
         """Take control of pawn
@@ -94,7 +97,8 @@ class PlayerPawnController(PawnController):
     def get_local_controller(cls):
         """Return the local player controller instance, or None if not found"""
         try:
-            return WorldInfo.subclass_of(PlayerPawnController)[0]
+            cont = WorldInfo.subclass_of(PlayerPawnController)[0]
+            return
 
         except IndexError:
             return None
@@ -103,10 +107,6 @@ class PlayerPawnController(PawnController):
         """Initialisation method"""
         self.initialise_client()
         self.initialise_server()
-
-        # Network clock
-        self.clock = Clock()
-        self.clock.possessed_by(self)
 
     @classmethod
     def get_input_map(cls):
@@ -133,6 +133,10 @@ class PlayerPawnController(PawnController):
     def initialise_server(self):
         """Initialise server-specific player controller state"""
         self.info = self.__class__.info_cls()
+
+        # Network clock
+        self.clock = Clock()
+        self.clock.possessed_by(self)
 
         # Network jitter compensation
         self.buffer = JitterBuffer(length=WorldInfo.to_ticks(0.1))
@@ -252,7 +256,9 @@ class PlayerPawnController(PawnController):
             client_state = self.client_moves_states[move_id]
 
         except KeyError:
-            logger.warn("Unable to verify client state for move: {}".format(move_id))
+            if move_id is not None:
+                logger.warn("Unable to verify client state for move: {}".format(move_id))
+
             return
 
         client_position, client_orientation = client_state

--- a/game_system/controllers.py
+++ b/game_system/controllers.py
@@ -44,7 +44,6 @@ class PawnController(Replicable):
     def on_notify(self, name):
         if name == "pawn":
             self.possess(self.pawn)
-            print("POSSESS")
 
     def on_deregistered(self):
         self.pawn.deregister()
@@ -96,12 +95,7 @@ class PlayerPawnController(PawnController):
     @classmethod
     def get_local_controller(cls):
         """Return the local player controller instance, or None if not found"""
-        try:
-            cont = WorldInfo.subclass_of(PlayerPawnController)[0]
-            return
-
-        except IndexError:
-            return None
+        return next(iter(WorldInfo.subclass_of(PlayerPawnController)), None)
 
     def on_initialised(self):
         """Initialisation method"""

--- a/game_system/entities.py
+++ b/game_system/entities.py
@@ -115,8 +115,8 @@ class Actor(ComponentEntity, Replicable):
 
         # If simulated, send rigid body state
         valid_role = (remote_role == Roles.simulated_proxy)
-        owner_accepts_physics = self.replicate_physics_to_owner or not is_owner
-        allowed_physics = self.replicate_simulated_physics and owner_accepts_physics and not self.transform.parent
+        allowed_physics = (self.replicate_simulated_physics and (self.replicate_physics_to_owner or not is_owner)
+                           and not self.transform.parent)
 
         if (valid_role and allowed_physics) or is_initial:
             yield "rigid_body_state"

--- a/game_system/entities.py
+++ b/game_system/entities.py
@@ -117,7 +117,6 @@ class Actor(ComponentEntity, Replicable):
         valid_role = (remote_role == Roles.simulated_proxy)
         allowed_physics = (self.replicate_simulated_physics and (self.replicate_physics_to_owner or not is_owner)
                            and not self.transform.parent)
-
         if (valid_role and allowed_physics) or is_initial:
             yield "rigid_body_state"
             yield "rigid_body_time"

--- a/network/connection.py
+++ b/network/connection.py
@@ -32,9 +32,9 @@ class Connection(metaclass=InstanceRegister):
         ip_info = address, port
 
         try:
-            return cls.get_from_graph(ip_info)
+            return cls[ip_info]
 
-        except LookupError:
+        except KeyError:
             return cls(ip_info)
 
     def on_initialised(self):

--- a/network/native_handlers.py
+++ b/network/native_handlers.py
@@ -67,11 +67,13 @@ class RolesHandler:
 
     @classmethod
     def pack(cls, roles):
-        """Pack roles for client
-        Switches remote and local roles
+        """Pack roles for client.
+
+        Switches remote and local roles.
 
         :param roles: role enum
-        :returms: packed roles (bytes)"""
+        :returns: packed roles (bytes)
+        """
         pack = cls.packer.pack
         return pack(roles.remote) + pack(roles.local)
 
@@ -446,22 +448,22 @@ class ReplicableBaseHandler:
 
         # Return only a replicable that was created by the network
         try:
-            replicable = WorldInfo.get_replicable(instance_id)
+            replicable = Replicable[instance_id]
             return replicable, id_size
 
-        except LookupError:
+        except KeyError:
             logger.exception("ReplicableBaseHandler: Couldn't find replicable with ID '{}'".format(instance_id))
             return None, id_size
 
     def unpack_multiple(self, bytes_string, count, offset=0):
         instance_ids, offset = self._packer.unpack_multiple(bytes_string, count, offset)
-        get_replicable = WorldInfo.get_replicable
+
         replicables = []
         for instance_id in instance_ids:
             try:
-                replicable = get_replicable(instance_id)
+                replicable = Replicable[instance_id]
 
-            except LookupError:
+            except KeyError:
                 replicable = None
                 logger.exception("ReplicableBaseHandler: Couldn't find replicable with ID '{}'".format(instance_id))
 

--- a/network/network.py
+++ b/network/network.py
@@ -245,19 +245,16 @@ class Network:
 
     def receive(self):
         """Receive all data from socket"""
-        # Get connections
-        get_connection = Connection.get_from_graph
-
         # Receives all incoming data
         for data, address in self.received_data:
             # Find existing connection for address
 
             try:
-                connection = get_connection(address, only_registered=False)
+                connection = Connection[address]
 
             # Create a new interface to handle connection
-            except LookupError:
-                connection = Connection(address)
+            except KeyError:
+                connection = Connection(address, register_immediately=True)
 
             # Dispatch data to connection
             connection.receive(data)

--- a/network/replicable.py
+++ b/network/replicable.py
@@ -67,9 +67,7 @@ class Replicable(metaclass=ReplicableRegister):
 
         # Walk the parent tree until no parent
         try:
-            #print("WALK TREE")
             while replicable:
-                #print(replicable, replicable.owner)
                 last, replicable = replicable, replicable.owner
 
         except AttributeError:

--- a/network/replicable.py
+++ b/network/replicable.py
@@ -112,8 +112,6 @@ class Replicable(metaclass=ReplicableRegister):
         roles = existing.roles
         roles.local, roles.remote = roles.remote, roles.local
 
-        print("CREATE", existing)
-
         return existing
 
     @classmethod
@@ -152,7 +150,6 @@ class Replicable(metaclass=ReplicableRegister):
 
         :param other: other replicable (owner)
         """
-        print("POSSESSED", self, other)
         self.owner = other
 
     def unpossessed(self):
@@ -205,9 +202,6 @@ class Replicable(metaclass=ReplicableRegister):
             yield "roles"
             yield "owner"
             yield "torn_off"
-
-            if self.__class__.__name__ == "Clock":
-                print(self.owner, "REPLICATE", self, self.owner.instance_id)
 
     def __description__(self):
         """Returns a hash-like description for this replicable.

--- a/network/streams/handshake.py
+++ b/network/streams/handshake.py
@@ -105,7 +105,6 @@ class ServerHandshakeStream(HandshakeStream):
             self.handshake_error = err
 
         else:
-            self.replication_stream = self.dispatcher.create_stream(ReplicationStream)
             self.state = ConnectionState.handshake
 
     @send_state(ConnectionState.handshake)
@@ -127,6 +126,7 @@ class ServerHandshakeStream(HandshakeStream):
                           on_success=self.on_ack_handshake_failed)
 
         else:
+            self.replication_stream = self.dispatcher.create_stream(ReplicationStream)
             # Set success state
             self.state = ConnectionState.connected
             ConnectionSuccessSignal.invoke(target=self)

--- a/network/streams/replication.py
+++ b/network/streams/replication.py
@@ -157,7 +157,6 @@ class ServerReplicationStream(ReplicationStream):
 
         :param target: replicable that was unregistered
         """
-
         # If the target is not in channel list, we don't need to delete
         if target.instance_id not in self.channels:
             return
@@ -305,9 +304,9 @@ class ClientReplicationStream(ReplicationStream):
         instance_id, _ = self.replicable_packer.unpack_id(data)
 
         try:
-            replicable = Replicable.get_from_graph(instance_id)
+            replicable = Replicable[instance_id]
 
-        except LookupError:
+        except KeyError:
             pass
 
         else:

--- a/network/world_info.py
+++ b/network/world_info.py
@@ -85,8 +85,7 @@ class _WorldInfo(Replicable):
             return self._replicable_lookup_cache[actor_type]
 
         except KeyError:
-            values = self._replicable_lookup_cache[actor_type] = [a for a in Replicable if isinstance(a, actor_type)]
-            return values
+            return []
 
     @simulated
     def update_clock(self, delta_time):
@@ -105,9 +104,9 @@ class _WorldInfo(Replicable):
         """
         return Replicable._by_types.get(name)
 
-    replicables = property(Replicable.get_graph_instances)
-    get_replicable = simulated(Replicable.get_from_graph)
-    has_replicable = simulated(Replicable.graph_has_instance)
+    @property
+    def replicables(self):
+        return Replicable._instances.values()
 
 
 WorldInfo = _WorldInfo(_WorldInfo._ID, register_immediately=True)

--- a/network/world_info.py
+++ b/network/world_info.py
@@ -33,12 +33,15 @@ class _WorldInfo(Replicable):
 
         :param target: Replicable instance
         """
-        if not type(target) in self._replicable_lookup_cache:
-            self._replicable_lookup_cache[type(target)] = []
+        cache = self._replicable_lookup_cache
 
-        for cls_type, values in self._replicable_lookup_cache.items():
-            if isinstance(target, cls_type):
-                values.append(target)
+        for base_cls in target.__class__.__mro__:
+            try:
+                instances = cache[base_cls]
+            except KeyError:
+                instances = cache[base_cls] = set()
+
+            instances.add(target)
 
     @ReplicableUnregisteredSignal.on_global
     @simulated
@@ -85,7 +88,7 @@ class _WorldInfo(Replicable):
             return self._replicable_lookup_cache[actor_type]
 
         except KeyError:
-            return []
+            return set()
 
     @simulated
     def update_clock(self, delta_time):

--- a/panda_game_system/definitions.py
+++ b/panda_game_system/definitions.py
@@ -79,6 +79,8 @@ class PandaPhysicsInterface(PandaComponent):
         self._node.notify_collisions(True)
         self._node.set_deactivation_enabled(False)
 
+        self._suspended_mass = None
+
     @staticmethod
     def entity_from_nodepath(nodepath):
         if not nodepath.has_python_tag("physics_component"):
@@ -132,6 +134,43 @@ class PandaPhysicsInterface(PandaComponent):
         hit_normal = Vector(result.get_hit_normal())
 
         return RayTestResult(hit_position, hit_normal, hit_entity, hit_distance)
+
+    @property
+    def type(self):
+        return PhysicsType.dynamic
+
+    @property
+    def suspended(self):
+        return self._suspended_mass is not None
+
+    @suspended.setter
+    def suspended(self, value):
+        if value == self.suspended:
+            return
+
+        if value:
+            self._suspended_mass = self._node.get_mass()
+            self._node.set_mass(0.0)
+
+        else:
+            self._node.set_mass(self._suspended_mass)
+            self._suspended_mass = None
+
+    @property
+    def mass(self):
+        if self.suspended:
+            return self._suspended_mass
+
+        else:
+            return self._node.get_mass()
+
+    @mass.setter
+    def mass(self, value):
+        if self.suspended:
+            self._suspended_mass = value
+
+        else:
+            self._node.set_mass(value)
 
     @property
     def is_colliding(self):

--- a/panda_game_system/game_loop.py
+++ b/panda_game_system/game_loop.py
@@ -122,7 +122,7 @@ class Server(GameLoop):
 
     @staticmethod
     def create_network():
-        return Network("localhost", 1200)
+        return Network("", 1200)
 
 
 class Client(GameLoop):
@@ -140,7 +140,7 @@ class Client(GameLoop):
 
     @staticmethod
     def create_network():
-        return Network("localhost", 0)
+        return Network("", 0)
 
     @ConnectToSignal.on_global
     def new_connection(self, address, port):

--- a/panda_game_system/game_loop.py
+++ b/panda_game_system/game_loop.py
@@ -122,7 +122,7 @@ class Server(GameLoop):
 
     @staticmethod
     def create_network():
-        return Network("", 1200)
+        return Network("localhost", 1200)
 
 
 class Client(GameLoop):
@@ -140,7 +140,7 @@ class Client(GameLoop):
 
     @staticmethod
     def create_network():
-        return Network("", 0)
+        return Network("localhost", 0)
 
     @ConnectToSignal.on_global
     def new_connection(self, address, port):

--- a/panda_game_system/physics.py
+++ b/panda_game_system/physics.py
@@ -205,7 +205,8 @@ class PandaClientPhysicsSystem(PandaPhysicsSystem):
             return
 
         # Make a list of actors which aren't us
-        other_actors = [a for a in WorldInfo.subclass_of(Actor) if a is not target]
+        other_actors = WorldInfo.subclass_of(Actor).copy()
+        other_actors.discard(target)
 
         with self.protect_exemptions(other_actors):
             self.world.doPhysics(delta_time)

--- a/panda_game_system/physics.py
+++ b/panda_game_system/physics.py
@@ -6,6 +6,7 @@ from network.world_info import WorldInfo
 
 from game_system.controllers import PlayerPawnController
 from game_system.entities import Actor
+from game_system.enums import PhysicsType
 from game_system.latency_compensation import PhysicsExtrapolator
 from game_system.physics import CollisionContact
 from game_system.signals import *
@@ -15,6 +16,9 @@ from .signals import RegisterPhysicsNode, DeregisterPhysicsNode
 from panda3d.bullet import BulletWorld
 from panda3d.core import loadPrcFileData
 from direct.showbase.DirectObject import DirectObject
+
+from contextlib import contextmanager
+
 #from panda3d.core import PythonCallbackObject
 
 loadPrcFileData('', 'bullet-enable-contact-events true')
@@ -128,9 +132,11 @@ class PandaServerPhysicsSystem(PandaPhysicsSystem):
 
 @with_tag(Netmodes.client)
 class PandaClientPhysicsSystem(PandaPhysicsSystem):
+    active_physics_types = {PhysicsType.dynamic, PhysicsType.rigid_body}
 
     def __init__(self):
         super().__init__()
+
 
         self._extrapolators = {}
 
@@ -139,14 +145,14 @@ class PandaClientPhysicsSystem(PandaPhysicsSystem):
         simulated_proxy = Roles.simulated_proxy
 
         controller = PlayerPawnController.get_local_controller()
-
-        if controller is None or controller.info is None:
+        if controller is None:
             return
 
         network_time = WorldInfo.elapsed + controller.info.ping / 2
 
         for actor, extrapolator in self._extrapolators.items():
             result = extrapolator.sample_at(network_time)
+
             if actor.roles.local != simulated_proxy:
                 continue
 
@@ -154,11 +160,55 @@ class PandaClientPhysicsSystem(PandaPhysicsSystem):
 
             current_orientation = actor.transform.world_orientation.to_quaternion()
             new_rotation = actor.rigid_body_state.orientation.to_quaternion()
-            slerped_orientation = current_orientation.slerp(new_rotation, 0.3)
+            slerped_orientation = current_orientation.slerp(new_rotation, 0.3).to_euler()
 
             actor.transform.world_position = position
             actor.physics.world_velocity = velocity
             actor.transform.world_orientation = slerped_orientation
+
+    @contextmanager
+    def protect_exemptions(self, exemptions):
+        """Suspend and restore state of exempted actors around an operation
+
+        :param exemptions: Iterable of exempt Actor instances
+        """
+        # Suspend exempted objects
+        already_suspended = set()
+
+        for actor in exemptions:
+            physics = actor.physics
+
+            if physics.suspended:
+                already_suspended.add(physics)
+                continue
+
+            physics.suspended = True
+
+        yield
+
+        # Restore scheduled objects
+        for actor in exemptions:
+            physics = actor.physics
+            if physics in already_suspended:
+                continue
+
+            physics.suspended = False
+
+    @PhysicsSingleUpdateSignal.on_global
+    def update_for(self, delta_time, target):
+        """Listener for PhysicsSingleUpdateSignal
+        Attempts to update physics simulation for single actor
+
+        :param delta_time: Time to progress simulation
+        :param target: Actor instance to update state"""
+        if target.physics.type not in self.active_physics_types:
+            return
+
+        # Make a list of actors which aren't us
+        other_actors = [a for a in WorldInfo.subclass_of(Actor) if a is not target]
+
+        with self.protect_exemptions(other_actors):
+            self.world.doPhysics(delta_time)
 
     @PhysicsReplicatedSignal.on_global
     def on_physics_replicated(self, timestamp, target):


### PR DESCRIPTION
-  Refactor InstanceManager to become more lightweight. 
-  Maintain order of registration/deregistration using list of pending operations.
-  Move instance ID assignment to registration operation, rather than waiting (to avoid ID clashes with randomly assigned IDs)
-  Support above change with network attributes - change `Replicable.__description__` to return Python ID
-  on_deregistered & on_registered callbacks now implement required functionality previously found in `_register_to_graph` etc.
-  Add fix for slerped orientation in extrapolate states (physics)
-  Add fix for `subclass_of` (don't calculate set for non-registered actors)
-  Move clock instantiation to Server
