### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,79 @@
+from setuptools import setup
+
+setup(name='network',
+      version='2.0.0',
+      description="Network package",
+      long_description="",
+      author='Angus Hollands',
+      author_email='goosey15@gmail.com',
+      license='MIT',
+      packages=['network', 'network.streams', 'network.streams.replication', 'network.serialiser', 'network.annotations', 'network.replication',
+       'network.type_serialisers', 'network.utilities'],
+      zip_safe=False,
+      install_requires=[
+          # 'Sphinx',
+          # ^^^ Not sure if this is needed on readthedocs.org
+          # 'something else?',
+          ],
+      )
+setup(name='bge_game_system',
+      version='2.0.0',
+      description="BGE network package",
+      long_description="",
+      author='Angus Hollands',
+      author_email='goosey15@gmail.com',
+      license='MIT',
+      packages=['bge_game_system', 'bge_game_system.entity'],
+      zip_safe=False,
+      install_requires=[
+          # 'Sphinx',
+          # ^^^ Not sure if this is needed on readthedocs.org
+          # 'something else?',
+          ],
+      )
+setup(name='panda_game_system',
+      version='2.0.0',
+      description="Panda3D network package",
+      long_description="",
+      author='Angus Hollands',
+      author_email='goosey15@gmail.com',
+      license='MIT',
+      packages=['panda_game_system'],
+      zip_safe=False,
+      install_requires=[
+          # 'Sphinx',
+          # ^^^ Not sure if this is needed on readthedocs.org
+          # 'something else?',
+          ],
+      )
+setup(name='game_system',
+      version='2.0.0',
+      description="Game System package",
+      long_description="",
+      author='Angus Hollands',
+      author_email='goosey15@gmail.com',
+      license='TODO',
+      packages=['game_system', 'game_system.ai', 'game_system.ai.behaviour', 'game_system.ai.planning', 'game_system.ai.state_machine', 'game_system.chat', 'game_system.chat', 'game_system.entity','game_system.geometry',
+                'game_system.latency_compensation', 'game_system.pathfinding', 'game_system.utilities'],
+      zip_safe=False,
+      install_requires=[
+          # 'Sphinx',
+          # ^^^ Not sure if this is needed on readthedocs.org
+          # 'something else?',
+          ],
+      )
+setup(name='tools',
+      version='2.0.0',
+      description="Tools package",
+      long_description="",
+      author='Angus Hollands',
+      author_email='goosey15@gmail.com',
+      license='TODO',
+      packages=['tools'],
+      zip_safe=False,
+      install_requires=[
+          # 'Sphinx',
+          # ^^^ Not sure if this is needed on readthedocs.org
+          # 'something else?',
+          ],
+      )

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+'''
+Created by agoose77.
+Modified by DonFlymor.
+'''
 from setuptools import setup
 
 setup(name='network',


### PR DESCRIPTION
Now pip and `python setup.py install` should work. Here are some instructions to get it tho work with pip (admin privileges may be 
needed):

To use command prompt: type cmd in the Windows search bar and click the “Command Prompt” icon. For admin,  type cmd in the Windows search bar and right click the “Command Prompt” icon, then click `run as administrator`.

Anything written like `this` will be entered in the command prompt.

`/PATH/TO/BLENDER/INSTALL/BLENDER_VERSION/python/bin/python.exe` is usually  `C:\Program Files\Blender Foundation\Blender\2.79\python\bin\python.exe` and can be replaced as such.

Messy way:
```bash
cd PATH/TO/GIT_REPO
/PATH/TO/BLENDER/INSTALL/BLENDER_VERSION/python/bin/python.exe setup.py install
```

Better way, **after someone sets PyAuthServer up in `pypi.org` online repo** (I can do it, if you'd like, and add you as a maintainer. I can even give you a way to make every github release (or tag) push a new version to `pypi.org` with github workflow):

Try this first
1.  ```bash
    /PATH/TO/BLENDER/INSTALL/BLENDER_VERSION/python/bin/python.exe -m pip help
    ```
If that doesn't return an error message, skip step 2

2. Download https://bootstrap.pypa.io/get-pip.py to Downloads folder as get-pip.py
    ```bash
    cd C:/Users/USER/Downloads/
    /PATH/TO/BLENDER/INSTALL/BLENDER_VERSION/python/bin/python.exe get-pip.py
    ```

3. ```bash
     /PATH/TO/BLENDER/INSTALL/BLENDER_VERSION/python/bin/python.exe -m pip install PyAuthServer
    ```